### PR TITLE
Build winrar

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 *
 !build.sh
+!build-windows.sh
 !install.*.xml
 !admin/controller/extension/shipping/sameday.php
 !admin/language/en-gb/extension/shipping/sameday.php

--- a/README.md
+++ b/README.md
@@ -1,0 +1,41 @@
+<div class="ac-textBlock" style=""><p><strong># Sameday Opencart Plugin</strong></p>
+<p>Acest repository este un <strong>plugin pentru Opencart</strong> dezvoltat de <strong>Sameday Courier</strong> Plugin-ul facilitează integrarea serviciilor de livrare Sameday în platformele de e-commerce bazate pe Opencart.</p>
+<h2>Funcționalități</h2>
+<ol>
+<li>
+<p><strong>Calculul tarifelor de livrare</strong>: Plugin-ul permite estimarea tarifelor de livrare Sameday și alte opțiuni configurabile.</p>
+</li>
+<li>
+<p><strong>Selectarea punctelor de ridicare și livrare</strong>: Utilizatorii pot alege punctele de ridicare și livrare.</p>
+</li>
+
+<li>
+<p><strong>Generarea AWB-urilor</strong>.</p>
+</li>
+</ol>
+<h2>Utilizare</h2>
+<h3>Instalare</h3>
+<ol>
+<li>Descarcă fișierul ocmod.zip, generat in urma rularii scriptului build.sh. Mergi pe pagina de admin la extensions installer. Dupa care mergi la extensions modification si apasa butonul refresh.</li>
+  !(imagine)[https://imgur.com/a/NBh6hDC]
+<li>Accesează panoul de administrare Opencart și activează plugin-ul în secțiunea <strong>Extensions &gt; Shipping</strong>.</li>
+</ol>
+<h3>Configurare</h3>
+<ol>
+<li>Accesează setările plugin-ului din panoul de administrare Opencart.</li>
+<li>Completează informațiile necesare pentru autentificarea la serviciile Sameday (utilizatorul, parola).</li>
+</ol>
+<h3>Pregătirea pentru instalare: ocmod.zip</h3>
+<p>Pentru a împacheta toate fișierele într-un arhivă <code>ocmod.zip</code>, folosește următoarea comandă:</p>
+<cib-code-block code-lang="bash" clipboard-data="./build.sh
+"><pre><code class="language-bash">./build.sh
+</code></pre>
+<li>Deschide terminalul.</li>
+<li>Navighează la directorul plugin-ului.</li>
+<li>Rulează comanda:</li>
+</ol>
+
+</cib-code-block><p>Asigură-te că ai permisiunile necesare pentru a executa scriptul.</p>
+<hr>
+<p>Acesta este un <strong>readme.md</strong> basic pentru plugin-ul Sameday Opencart. Astept sugestiile tale de imbunatatiri!🚚</p>
+</div>

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
 <h3>Instalare</h3>
 <ol>
 <li>Descarcă fișierul ocmod.zip, generat in urma rularii scriptului build.sh. Mergi pe pagina de admin la extensions installer. Dupa care mergi la extensions modification si apasa butonul refresh.</li>
-  !(imagine)[https://imgur.com/a/NBh6hDC]
+  ![alt text](https://github.com/takegabriel08/sameday-opencart-plugin/blob/master/image.jpg?raw=true)
 <li>Accesează panoul de administrare Opencart și activează plugin-ul în secțiunea <strong>Extensions &gt; Shipping</strong>.</li>
 </ol>
 <h3>Configurare</h3>

--- a/README.md
+++ b/README.md
@@ -17,7 +17,6 @@
 <h3>Instalare</h3>
 <ol>
 <li>Descarcă fișierul ocmod.zip, generat in urma rularii scriptului build.sh. Mergi pe pagina de admin la extensions installer. Dupa care mergi la extensions modification si apasa butonul refresh.</li>
-  ![alt text](https://github.com/takegabriel08/sameday-opencart-plugin/blob/master/image.jpg?raw=true)
 <li>Accesează panoul de administrare Opencart și activează plugin-ul în secțiunea <strong>Extensions &gt; Shipping</strong>.</li>
 </ol>
 <h3>Configurare</h3>

--- a/build-windows.sh
+++ b/build-windows.sh
@@ -1,0 +1,67 @@
+#!/bin/sh
+
+if [ -z "$1" ]; then
+    echo "Please specify version to build"
+    exit 1
+fi
+
+WINRAR_PATH="/c/Program Files/WinRAR/WinRAR.exe"
+
+
+VERSION=$1
+if [ $VERSION -eq 2 ]; then
+    rm sameday.$VERSION.ocmod.zip
+    rm -rf upload
+    mkdir upload
+
+    cp -r --parents \
+        admin/controller/extension/shipping/sameday.php \
+        admin/language/en-gb/extension/shipping/sameday.php \
+        admin/model/extension/shipping/sameday.php \
+        admin/view/template/extension/shipping/sameday.tpl \
+        admin/view/template/extension/shipping/sameday_add_awb.tpl \
+        admin/view/template/extension/shipping/sameday_awb_history_status.tpl \
+        admin/view/template/extension/shipping/sameday_awb_history_status_refresh.tpl \
+        admin/view/template/extension/shipping/sameday_service.tpl \
+        catalog/model/extension/shipping/sameday.php \
+        system/library/sameday-php-sdk/ \
+        system/library/sameday-classes/ \
+        system/library/samedayclasses.php \
+        upload
+
+    cp install.$VERSION.xml install.xml
+    "${WINRAR_PATH}" -r sameday.$VERSION.ocmod.zip upload install.xml
+    rm install.xml
+    rm -rf upload
+
+    exit
+elif [ $VERSION -eq 3 ]; then
+    rm sameday.$VERSION.ocmod.zip
+    rm -rf upload
+    mkdir upload
+
+    cp -r --parents \
+        admin/controller/extension/shipping/sameday.php \
+        admin/language/en-gb/extension/shipping/sameday.php \
+        admin/model/extension/shipping/sameday.php \
+        admin/view/template/extension/shipping/sameday.twig \
+        admin/view/template/extension/shipping/sameday_add_awb.twig \
+        admin/view/template/extension/shipping/sameday_awb_history_status.twig \
+        admin/view/template/extension/shipping/sameday_awb_history_status_refresh.twig \
+        admin/view/template/extension/shipping/sameday_service.twig \
+        catalog/model/extension/shipping/sameday.php \
+        system/library/sameday-php-sdk/ \
+        system/library/sameday-classes/ \
+        system/library/samedayclasses.php \
+        upload
+
+    cp install.$VERSION.xml install.xml
+    "${WINRAR_PATH}" a -afzip -r sameday.$VERSION.ocmod.zip upload install.xml
+    rm install.xml
+    rm -rf upload
+
+    exit
+fi
+
+echo "Unknown version $VERSION specified"
+exit 1


### PR DESCRIPTION
Added another build script: "build-windows.sh" that is using winrar to build the files instead of zip.
If winrar is installed as default installation it will work directly.
If not I explained in the readme.md how to update winrar path without having to add winrar to environment variables.